### PR TITLE
Add simulador to diagrams

### DIFF
--- a/docs/diagrama_microservicios.drawio
+++ b/docs/diagrama_microservicios.drawio
@@ -21,6 +21,11 @@
           <mxGeometry x="60" y="60" width="200" height="80" as="geometry"/>
         </mxCell>
 
+        <!-- Simulador -->
+        <mxCell id="simulador" value="Simulador&#xa;[Contenedor: Python 3.x]&#xa;Genera pagos simulados." style="shape=rectangle;whiteSpace=wrap;html=1;rounded=1;fillColor=#d4eaff;fontSize=12;" vertex="1" parent="1">
+          <mxGeometry x="640" y="60" width="200" height="80" as="geometry"/>
+        </mxCell>
+
         <!-- Notificador -->
         <mxCell id="notificador" value="Notificador&#xa;[Contenedor: Python 3.x, Flask 2.x]&#xa;Generar el documento de la póliza de un asegurado." style="shape=rectangle;whiteSpace=wrap;html=1;rounded=1;fillColor=#d4eaff;fontSize=12;" vertex="1" parent="1">
           <mxGeometry x="60" y="180" width="200" height="80" as="geometry"/>
@@ -67,6 +72,10 @@
         </mxCell>
 
         <mxCell id="line2" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;" edge="1" parent="1" source="telegram" target="notificador">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="line3" style="edgeStyle=orthogonalEdgeStyle;rounded=0;html=1;endArrow=block;" edge="1" parent="1" source="gateway" target="simulador">
           <mxGeometry relative="1" as="geometry"/>
         </mxCell>
 

--- a/docs/elementos.drawio
+++ b/docs/elementos.drawio
@@ -28,6 +28,10 @@
                 <mxCell id="notificador" value="Notificador&#xa;[Contenedor: Python 3.x, Flask 2.x]&#xa;Generar el documento de la póliza de un asegurado." style="rounded=1;whiteSpace=wrap;html=1;fillColor=#9CC3E6;" parent="1" vertex="1">
                     <mxGeometry x="690" y="260" width="240" height="80" as="geometry"/>
                 </mxCell>
+
+                <mxCell id="simulador" value="Simulador&#xa;[Contenedor: Python 3.x]&#xa;Genera pagos simulados." style="rounded=1;whiteSpace=wrap;html=1;fillColor=#9CC3E6;" parent="1" vertex="1">
+                    <mxGeometry x="350" y="360" width="220" height="80" as="geometry"/>
+                </mxCell>
                 <mxCell id="telegram" value="TELEGRAM&#xa;[Herramienta de mensajería]&#xa;Recibe el mensaje y el pdf de actualización de la&#xa;póliza solicitada al chat del Bot." style="rounded=1;whiteSpace=wrap;html=1;fillColor=#BDD7EE;" parent="1" vertex="1">
                     <mxGeometry x="750" y="360" width="200" height="80" as="geometry"/>
                 </mxCell>
@@ -53,6 +57,10 @@
                     <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
                 <mxCell id="9" style="endArrow=block;" parent="1" source="notificador" target="telegram" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+
+                <mxCell id="10" style="endArrow=block;" parent="1" source="api" target="simulador" edge="1">
                     <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
             </root>


### PR DESCRIPTION
## Summary
- update microservices diagram with Simulador node and connection
- update elementos diagram with Simulador node and connection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mongomock')*
- `pip install -q -r gestor-de-clientes/requirements.txt`
- `pip install -q -r notificador/requirements.txt` *(fails building wheel for aiohttp, yarl, frozenlist)*

------
https://chatgpt.com/codex/tasks/task_e_684c6280af548321af0f691d410b200a